### PR TITLE
Refactor MIDI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ In a `poetry` shell, run open a Python REPL.
 ```python
 >>> from allegro.midi import MidiOut
 >>> m = MidiOut()
->>> m.get_available_ports() # you should see "SimpleSynth virtual input" listed here. The first value in the tuple is the port_id.
-[(0, "SimpleSynth virtual input")]
->>> m.port_id = 0
+>>> ports = m.get_available_ports() # you should see "SimpleSynth virtual input" listed here.
+[MidiPort(port_id=0, port_name='SimpleSynth virtual input')]
+>>> m.port_id = ports[0].port_id
 >>> m.open_output()
 >>> m.test() # plays a short and random composition.
 ```

--- a/README.md
+++ b/README.md
@@ -85,19 +85,9 @@ Open SimpleSynth and select "SimpleSynth virtual input" as the input source.
 In a `poetry` shell, run open a Python REPL.
 
 ```python
->>> from allegro.midi import MidiOut
->>> m = MidiOut()
->>> ports = m.get_available_ports() # you should see "SimpleSynth virtual input" listed here.
+>>> from allegro import midi
+>>> ports = midi.get_available_ports() # you should see "SimpleSynth virtual input" listed here.
 [MidiPort(port_id=0, port_name='SimpleSynth virtual input')]
->>> m.port_id = ports[0].port_id
->>> m.open_output()
+>>> m = midi.MidiOut(0)
 >>> m.test() # plays a short and random composition.
-```
-
-If you know the `port_id` you can simplify the initialization like so:
-
-```python
->>> from allegro.midi import MidiOut
->>> m = MidiOut(port_id=0)
->>> m.test()
 ```

--- a/allegro/midi.py
+++ b/allegro/midi.py
@@ -2,7 +2,7 @@ import dataclasses
 import logging
 import random
 import time
-from typing import List, Optional
+from typing import List
 
 import rtmidi
 from rtmidi.midiutil import open_midioutput
@@ -26,103 +26,69 @@ class MidiPort:
     port_name: str
 
 
+def get_output_ports() -> List[MidiPort]:
+    """
+    get_available_ports returns all available midi output ports.
+
+    This returns a list of MidiPort objects.
+    """
+    ports = rtmidi.MidiOut().get_ports()
+    port_ids_and_names = [
+        MidiPort(port_id=port_id, port_name=name) for port_id, name in enumerate(ports)
+    ]
+    log.debug(port_ids_and_names)
+    return port_ids_and_names
+
+
 class MidiOut:
     """
-    MidiOut handles midi output related activities.
-
-    Properties:
-    midiout -- access to the rtmidi MidiOut object.
-    port_id -- an integer representing a midi port.
-    output -- after initialization by open_output, output is
-    a port that can receive midi messages.
-
+    MidiOut opens a MIDI output connection.
 
     Methods:
-    get_available_ports -- returns all available midi output ports.
-    open_output -- opens a midi port for output.
+    play -- plays a midi note with given velocity and duration.
     test -- writes a random compositon and sends it to the initialized output.
     """
 
-    def __init__(self, port_id: int = None):
-        self.midiout = rtmidi.MidiOut()
-        self._port_id = port_id
-        self.output = None
-        if port_id:
-            log.debug(f"initializing MidiOut with port_id: {port_id}")
-            self.open_output(port_id)
+    def __init__(self, port_id: int):
+        self.port_id = port_id
+        self.output = self._open_output()
 
-    @property
-    def port_id(self) -> Optional[int]:
-        """
-        port_id gets the port_id for the class.
-        """
-        log.debug(f"getting port_id of value {self._port_id}")
-        return self._port_id
-
-    @port_id.setter
-    def port_id(self, port_id: int) -> None:
-        """
-        port_id sets the port_id for the class.
-        """
-        log.debug(f"setting port to {port_id}")
-        self._port_id = port_id
-
-    def get_available_ports(self) -> List[MidiPort]:
-        """
-        get_available_ports returns all available midi output ports.
-
-        These are returned in a list of tuples in which the port_id is
-        the first member of the tuple and the port name is the second.
-
-        Ex: [(0, "Virtual IAC Bus"), (1, "SimpleSynth")]
-        """
-        ports = self.midiout.get_ports()
-        port_ids_and_names = [
-            MidiPort(port_id=port_id, port_name=name)
-            for port_id, name in enumerate(ports)
-        ]
-        log.debug(port_ids_and_names)
-        return port_ids_and_names
-
-    def open_output(self, port_id=None) -> None:
+    def _open_output(self) -> rtmidi.MidiOut:
         """
         open_output opens a midi port for output.
-
-        open_port can take the port_id to be opened as an argument or
-        it can use the class's port_id property.
-
-        optional arguments:
-        port -- int: the port to open.
         """
-        if not self.port_id and not port_id:
-            log.error("Cannot open output without port selected.")
-            return
-        try:
-            midiout, _ = open_midioutput(self.port_id)
-            self.output = midiout
-        except (EOFError, KeyboardInterrupt) as e:
-            log.error(f"Could not open port. Hint: Check that valid port is set. {e}")
+        if not self.port_id:
+            err_text = "Cannot open output without port selected."
+            log.error(err_text)
+            raise RuntimeError(err_text)
+
+        midiout, _ = open_midioutput(self.port_id)
+        return midiout
+
+    def play(self, note: int, vel: int, dur: float):
+        self.output.send_message([NOTE_ON, note, vel])
+        time.sleep(dur)
+        self.output.send_message([NOTE_OFF, note, 0])
+
+    def _random_event(self):
+        note = random.choice(range(30, 90))
+        dur = random.choice([0.1, 0.2, 0.5])
+        vel = random.choice([128, 100, 80, 60])
+        return note, dur, vel
 
     def test(self):
         """
         test writes a random compositon and sends it to
         the initialized output.
 
-        test will return early and log an error if there
+        test will log an error and raise an exception if there
         is not an open output available.
         """
         if not self.output:
-            log.error("Cannot test without open output.")
-            return
-
-        def random_event():
-            note = random.choice(range(30, 90))
-            dur = random.choice([0.1, 0.2, 0.5])
-            vel = random.choice([128, 100, 80, 60])
-            return note, dur, vel
+            err_text = "Cannot test without open output."
+            log.error(err_text)
+            raise RuntimeError(err_text)
 
         for _ in range(10):
-            note, dur, vel = random_event()
-            self.output.send_message([NOTE_ON, note, vel])
-            time.sleep(dur)
-            self.output.send_message([NOTE_OFF, note, 0])
+            note, dur, vel = self._random_event()
+            self.play(note, vel, dur)

--- a/allegro/midi.py
+++ b/allegro/midi.py
@@ -16,7 +16,7 @@ logging.basicConfig(level=logging.DEBUG)
 @dataclasses.dataclass
 class MidiPort:
     """
-    MidiPort represents a MIDI port. 
+    MidiPort represents a MIDI port.
 
     port_id -- int
     port_name -- str

--- a/poetry.lock
+++ b/poetry.lock
@@ -215,6 +215,20 @@ pytest = ">=3.6"
 testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "virtualenv"]
 
 [[package]]
+category = "dev"
+description = "Thin-wrapper around the mock package for easier use with py.test"
+name = "pytest-mock"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.0.0"
+
+[package.dependencies]
+pytest = ">=2.7"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+
+[[package]]
 category = "main"
 description = "A Python binding for the RtMidi C++ library implemented using Cython."
 name = "python-rtmidi"
@@ -263,7 +277,7 @@ python-versions = "*"
 version = "0.1.8"
 
 [metadata]
-content-hash = "88597964fc702b4f95af947ceea05646edc8577f6a8038f12bb04911c4645c9d"
+content-hash = "f8e9320014d326dbe783ff9ee88ae4394cb1c8e215d48176f2f87c2ef27bcfdc"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -375,6 +389,10 @@ pytest = [
 pytest-cov = [
     {file = "pytest-cov-2.8.1.tar.gz", hash = "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b"},
     {file = "pytest_cov-2.8.1-py2.py3-none-any.whl", hash = "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"},
+]
+pytest-mock = [
+    {file = "pytest-mock-2.0.0.tar.gz", hash = "sha256:b35eb281e93aafed138db25c8772b95d3756108b601947f89af503f8c629413f"},
+    {file = "pytest_mock-2.0.0-py2.py3-none-any.whl", hash = "sha256:cb67402d87d5f53c579263d37971a164743dc33c159dfb4fb4a86f37c5552307"},
 ]
 python-rtmidi = [
     {file = "python-rtmidi-1.3.1.tar.gz", hash = "sha256:f9d2a1b5374b2e6856006537b6d4d5ceed4db4c4ee60caec4af83707a78297e4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ pytest = "^5.2"
 flake8 = "^3.7.9"
 black = {version = "^19.10b0", allow-prereleases = true}
 pytest-cov = "^2.8.1"
+pytest-mock = "^2.0.0"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Simplify the design by moving `get_output_ports` to a module level function. This allows clients to instantiate the MidiOut class using the port_id. 

Add MidiPort dataclass to make working with MidiPort info easier/more accessible.