### PR TITLE
Rename numbers to transform. Cleanup docs.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length=100
+ignore=E741

--- a/allegro/transform.py
+++ b/allegro/transform.py
@@ -1,9 +1,9 @@
 # pyright: strict
 
 """
-numbers.py
+transform.py
 
-The numbers module contains functions and classes that do "numeric"
+The transform module contains functions and classes that do "numeric"
 transformations.
 """
 import math

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,4 +1,4 @@
-from allegro.numbers import (
+from allegro.transfrom import (
     QuantizeMode,
     deltas,
     fit,

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,4 +1,4 @@
-from allegro.transfrom import (
+from allegro.transform import (
     QuantizeMode,
     deltas,
     fit,


### PR DESCRIPTION
Why: Give numbers a more fitting name.

Tags: docs, cleanup