### PR TITLE
Add keynum to notename converter.

### DIFF
--- a/allegro/midi.py
+++ b/allegro/midi.py
@@ -8,7 +8,6 @@ import rtmidi
 from rtmidi.midiutil import open_midioutput
 from rtmidi.midiconstants import NOTE_ON, NOTE_OFF
 
-
 log = logging.getLogger("allegro.midi")
 logging.basicConfig(level=logging.DEBUG)
 
@@ -92,3 +91,37 @@ class MidiOut:
         for _ in range(10):
             note, dur, vel = self._random_event()
             self.play(note, vel, dur)
+
+
+def keynum_to_notename(keynum: int) -> str:
+    """
+    keynum_to_notename takes a MIDI keynumber and converts it
+    to a notename.
+
+    args: keynum: int
+
+    returns: str
+    """
+    log.debug(f"received {keynum}")
+    notenames = [
+        "C",
+        "Db",
+        "D",
+        "Eb",
+        "E",
+        "F",
+        "Gb",
+        "G",
+        "Ab",
+        "A",
+        "Bb",
+        "B",
+    ]
+
+    notename = notenames[keynum % 12]
+    octave = (keynum // 12) - 1  # 60 is C4 aka middle C
+    result = notename + str(octave)
+
+    log.debug(f"result: {result}")
+    return result
+

--- a/tests/test_midi.py
+++ b/tests/test_midi.py
@@ -1,0 +1,13 @@
+from allegro.midi import keynum_to_notename
+
+
+def test_keynum_to_notename():
+
+    assert keynum_to_notename(21) == "A0"
+    assert keynum_to_notename(60) == "C4"
+    assert keynum_to_notename(59) == "B3"
+
+    # test bounds
+    assert keynum_to_notename(0) == "C-1"
+    assert keynum_to_notename(127) == "G9"
+


### PR DESCRIPTION
Why: Need a way to convert keynums into notenames.

How: Adding a new function to the midi module and writing some tests.

Tags: midi, conversion