### PR TITLE
Add a caching module.

### DIFF
--- a/allegro/cache.py
+++ b/allegro/cache.py
@@ -1,0 +1,61 @@
+"""Cache module provides utilities for caching.
+
+This module provides utilities for caching results to disk.
+It follows the XDG Base Directory Configuration guidance, and as such caches to
+$XDG_CACHE_HOME or $HOME/.cache if $XDG_CACHE_HOME is not set.
+"""
+import json
+import os
+
+from typing import Optional, Any
+
+Serializable = Any  # this doesn't help with type hints at all but is for documentation
+
+
+class SerializableError(Exception):
+    pass
+
+
+def _get_cache_dir() -> str:
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+
+    if not xdg_cache_home:
+        fallback_path = os.path.join(os.environ.get("HOME"), ".cache")
+        xdg_cache_home = fallback_path
+
+    allegro_cache = os.path.join(xdg_cache_home, "allegro")
+    return allegro_cache
+
+
+class Cache:
+    def __init__(self, cache_dir: Optional[str] = None):
+        self.cache_dir = cache_dir if cache_dir else _get_cache_dir()
+
+    def _create_cache_dir(self):
+        try:
+            os.mkdir(self.cache_dir)
+        except FileExistsError:
+            pass
+
+    def save(self, serializable_object: Serializable, filename: str):
+        self._create_cache_dir()
+
+        try:
+            serialized = json.dumps(serializable_object)
+        except (TypeError, OverflowError):
+            raise SerializableError("Cannot serialize this object.")
+
+        cache_filename = os.path.join(self.cache_dir, filename)
+
+        with open(cache_filename, "w+") as f:
+            f.write(serialized)
+
+    def load(self, filename: str) -> Serializable:
+        filepath = os.path.join(self.cache_dir, filename)
+        if not os.path.exists(filepath):
+            raise IOError(f"File {filepath} does not exist.")
+
+        with open(filepath, "r") as f:
+            contents = f.read()
+            deserialized = json.loads(contents)
+            return deserialized

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,62 @@
+from allegro.cache import Cache, SerializableError
+import os
+import pytest
+
+
+def test_get_cache_dir(mocker):
+    expected_cache_dir = "/Users/alexbielen/.cache/allegro"
+    mocker.patch.dict(
+        "allegro.cache.os.environ", {"XDG_CACHE_HOME": "/Users/alexbielen/.cache"}
+    )
+    c = Cache()
+    assert c.cache_dir == expected_cache_dir
+
+
+def test_get_cache_dir_fallback(mocker):
+    expected_cache_dir = "/Users/alexbielen/.cache/allegro"
+    mocker.patch.dict(
+        "allegro.cache.os.environ", {"XDG_CACHE_HOME": "", "HOME": "/Users/alexbielen/"}
+    )
+    c = Cache()
+    assert c.cache_dir == expected_cache_dir
+
+
+def test_create_file(tmpdir, mocker):
+    mocker.patch("allegro.cache._get_cache_dir", return_value=tmpdir)
+    c = Cache()
+    l = [1, 2, 3]
+    c.save(l, "cached_list")
+    loaded_list = c.load("cached_list")
+    assert l == loaded_list
+
+
+def test_create_file_with_dirname(tmpdir, mocker):
+    mocker.patch("allegro.cache._get_cache_dir", return_value=tmpdir)
+    c = Cache(cache_dir=tmpdir)
+    l = [1, 2, 3]
+    c.save(l, "cached_list")
+    loaded_list = c.load("cached_list")
+    assert l == loaded_list
+
+
+def test_lookup_file_that_does_not_exist(tmpdir, mocker):
+    mocker.patch("allegro.cache._get_cache_dir", return_value=tmpdir)
+    c = Cache(cache_dir=tmpdir)
+
+    with pytest.raises(IOError) as e_info:
+        filename = "dne.txt"
+        c.load(filename)
+
+    expected_message = f"File {os.path.join(tmpdir, filename)} does not exist."
+    assert e_info.value.args[0] == expected_message
+
+
+def test_that_serializable_exception_is_thrown(tmpdir, mocker):
+    mocker.patch("allegro.cache._get_cache_dir", return_value=tmpdir)
+    c = Cache(cache_dir=tmpdir)
+
+    with pytest.raises(SerializableError) as exc_info:
+        c.save(lambda i: i, "function")
+
+    assert exc_info.value.args[0] == "Cannot serialize this object."
+


### PR DESCRIPTION
Why: I need a way to save the expensive results from the constraint
programming library to disk and load them back up again.

Also, add hashing algorithm to constraint problem. I'm thinking of doing
an "autocache", but it'll probably be too big of a headache.

How: Adding a caching module. This creates a cache directory in
XDG_CACHE_HOME or if that doesn't exist, $HOME/.cache. It adds a clas
`Cache` which has two methods, `save` and `load`. `save` writes any
JSON-serializable to to the cache directory. `load` looks for a json
file matching the name parameter and deserializes the JSON into python.

Tags: caching, JSON, XDG