### PR TITLE
Clean up pitchclass.rs code.

### DIFF
--- a/.cursor/rules/solid-rust.mdc
+++ b/.cursor/rules/solid-rust.mdc
@@ -1,0 +1,30 @@
+---
+description: Outlines the SOLID principles to apply in the codebase, in rust fashion
+alwaysApply: true
+---
+
+## Rust SOLID Guidelines
+
+When changing this codebase, prefer small, explicit Rust abstractions over broad object-oriented patterns. Apply SOLID as practical design pressure, not ceremony.
+
+### Single Responsibility Principle
+
+Keep structs, modules, and functions focused on one reason to change. A data type should model data or behavior clearly; it should not also own unrelated concerns such as file I/O, network access, logging, or persistence. Split responsibilities into focused modules such as `Config`, `ConfigLoader`, and `ConfigWriter`.
+
+### Open/Closed Principle
+
+Prefer extension through traits, implementations, and composition rather than editing stable code paths. When adding a new variant of behavior, consider whether a trait plus a new implementation is cleaner than expanding a central `match`, enum, or conditional chain. Do not over-abstract prematurely; use traits where extension is expected.
+
+### Liskov Substitution Principle
+
+Every type implementing a trait must honor the trait’s contract. Do not implement methods with surprising panics, no-op behavior, or weakened guarantees. If only some types support behavior, split the behavior into a smaller trait instead of forcing all implementors to fake it.
+
+### Interface Segregation Principle
+
+Use small, focused traits. Prefer traits on the size of `Readable`, `Writable`, `Validates`, or `SendsMessage` over large “god traits.” A type should only implement capabilities it actually supports.
+
+### Dependency Inversion Principle
+
+High-level application logic should depend on traits, not concrete infrastructure. Inject dependencies through generics, trait bounds, or `dyn Trait` where appropriate. Keep concrete adapters for databases, filesystems, HTTP clients, queues, and email/SMS providers at the edges of the system.
+
+Favor clarity, ownership-safe APIs, and testable seams over unnecessary abstraction.

--- a/src/pitchclass.rs
+++ b/src/pitchclass.rs
@@ -3,6 +3,39 @@ use pyo3::prelude::*;
 use crate::forte_lookup::forte_for_prime_form;
 use crate::utils::has_unique_elements;
 
+// ============ PitchClass primitive ============
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct PitchClass(i8);
+
+impl PitchClass {
+    fn try_new(pc: i8) -> PyResult<Self> {
+        crate::error::require((0..=11).contains(&pc), "pc must be within the range 0-11")?;
+        Ok(Self(pc))
+    }
+
+    fn raw(self) -> i8 {
+        self.0
+    }
+
+    fn invert(self) -> Self {
+        Self((-self.0).rem_euclid(12))
+    }
+
+    fn transpose(self, semitones: i8) -> Self {
+        Self((self.0 + semitones).rem_euclid(12))
+    }
+}
+
+fn validate_semitones(s: i8) -> PyResult<()> {
+    crate::error::require(
+        (-11..=11).contains(&s),
+        "by_semitones must be within the range (-11)-11",
+    )
+}
+
+// ============ PitchClassSet (PyO3 class) ============
+
 /// A collection of distinct pitch classes.
 ///
 /// `PitchClassSet` represents a collection of distinct pitch classes,
@@ -15,7 +48,21 @@ use crate::utils::has_unique_elements;
 #[pyclass]
 #[derive(Clone)]
 pub struct PitchClassSet {
-    pub pcs: Vec<i8>,
+    pcs: Vec<PitchClass>,
+}
+
+impl PitchClassSet {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.pcs.is_empty()
+    }
+
+    pub(crate) fn pcs_i8(&self) -> Vec<i8> {
+        self.pcs.iter().copied().map(PitchClass::raw).collect()
+    }
+
+    pub(crate) fn first_pc_i8(&self) -> Option<i8> {
+        self.pcs.first().map(|pc| pc.raw())
+    }
 }
 
 #[pymethods]
@@ -36,17 +83,15 @@ impl PitchClassSet {
     ///     ValueError: If any pitch class is outside the range 0–11.
     #[new]
     fn new(pitch_classes: Vec<i8>) -> PyResult<Self> {
-        if !has_unique_elements(&pitch_classes) {
-            return Err(pyo3::exceptions::PyValueError::new_err(
-                "pitch classes must be unique",
-            ));
-        }
-
-        for &pc in &pitch_classes {
-            pc_guard(pc)?;
-        }
-
-        Ok(Self { pcs: pitch_classes })
+        crate::error::require(
+            has_unique_elements(&pitch_classes),
+            "pitch classes must be unique",
+        )?;
+        let pcs = pitch_classes
+            .into_iter()
+            .map(PitchClass::try_new)
+            .collect::<PyResult<Vec<_>>>()?;
+        Ok(Self { pcs })
     }
 
     /// Get the pitch classes in this set.
@@ -63,12 +108,12 @@ impl PitchClassSet {
     ///     [0, 2, 4, 7]
     #[getter]
     fn pitch_classes(&self) -> Vec<i8> {
-        self.pcs.clone()
+        self.pcs_i8()
     }
 
     /// Compute the normal form of the pitch-class set.
     ///
-    /// The normal form is the most “compact” ordering of the set when treated as
+    /// The normal form is the most "compact" ordering of the set when treated as
     /// an ascending scale within a single octave.
     ///
     /// Algorithm:
@@ -83,7 +128,7 @@ impl PitchClassSet {
     ///        from the left:
     ///            - Then (second-to-last - first), if still tied,
     ///            - Then (third-to-last - first), and so on
-    ///        Keep only the most “left-packed” (most compact toward the beginning).
+    ///        Keep only the most "left-packed" (most compact toward the beginning).
     ///
     ///     4. If a tie still remains, choose the ordering whose first pitch class
     ///        is smallest.
@@ -99,7 +144,7 @@ impl PitchClassSet {
     ///     `src/specs/pitchclass.md`.
     #[getter]
     fn normal_form(&self) -> Vec<i8> {
-        get_normal_form(&sorted_pitch_classes(&self.pcs))
+        normal_form(&sorted_pcs_i8(&self.pcs))
     }
 
     /// Compute the Rahn prime form of the pitch-class set.
@@ -112,13 +157,13 @@ impl PitchClassSet {
     ///     list[int]: The prime form of the set as pitch classes in the range 0–11.
     #[getter]
     fn prime_form(&self) -> Vec<i8> {
-        let sorted = sorted_pitch_classes(&self.pcs);
-        let nf = get_normal_form(&sorted);
-        let mut inverted: Vec<i8> = sorted.iter().copied().map(invert_pc).collect();
+        let sorted = sorted_pcs_i8(&self.pcs);
+        let nf = normal_form(&sorted);
+        let mut inverted: Vec<i8> = self.pcs.iter().map(|pc| pc.invert().raw()).collect();
         inverted.sort_unstable();
-        let nf_inv = get_normal_form(&inverted);
-        let prime_from_set = transpose_prime_to_zero(&nf);
-        let prime_from_inv = transpose_prime_to_zero(&nf_inv);
+        let nf_inv = normal_form(&inverted);
+        let prime_from_set = transpose_to_zero(&nf);
+        let prime_from_inv = transpose_to_zero(&nf_inv);
         std::cmp::min(prime_from_set, prime_from_inv)
     }
 
@@ -159,8 +204,8 @@ impl PitchClassSet {
     ///     >>> pcs.interval_vector
     ///     [0, 0, 1, 1, 1, 0]
     #[getter]
-    fn interval_vector(&self) -> PyResult<Vec<i8>> {
-        Ok(interval_class_vector(&self.pcs))
+    fn interval_vector(&self) -> Vec<i8> {
+        interval_class_vector(&self.pcs_i8())
     }
 
     /// Generate all subsets of the pitch-class set.
@@ -176,23 +221,21 @@ impl PitchClassSet {
     /// Returns:
     ///     list[PitchClassSet]: Subsets of the pitch-class set whose length is at least ``min_size``.
     #[pyo3(signature = (min_size = 0))]
-    fn subsets(&self, min_size: usize) -> PyResult<Vec<Self>> {
-        let mut subsets = Vec::new();
+    fn subsets(&self, min_size: usize) -> Vec<Self> {
         let n = self.pcs.len();
-        for i in 0..(1usize << n) {
-            if (i.count_ones() as usize) < min_size {
-                continue;
-            }
-            let subset = self
-                .pcs
-                .iter()
-                .enumerate()
-                .filter(|(j, _)| i & (1usize << j) != 0)
-                .map(|(_, &pc)| pc)
-                .collect();
-            subsets.push(Self { pcs: subset });
-        }
-        Ok(subsets)
+        (0..(1usize << n))
+            .filter(|i| i.count_ones() as usize >= min_size)
+            .map(|i| {
+                let pcs = self
+                    .pcs
+                    .iter()
+                    .enumerate()
+                    .filter(|(j, _)| i & (1usize << j) != 0)
+                    .map(|(_, &pc)| pc)
+                    .collect();
+                Self { pcs }
+            })
+            .collect()
     }
 
     /// Count how many pitch classes are shared between this set and its transposition by ``tn``
@@ -210,7 +253,7 @@ impl PitchClassSet {
     ///
     /// Under **tritone** transposition, i.e. ``Tn6``, common tones are **twice** the entry in
     /// the interval-class vector.
-    /// See Open Music Theory, “Common Tones under Transposition”
+    /// See Open Music Theory, "Common Tones under Transposition"
     /// (<https://openmusictheory.github.io/commonTonesUnderTransposition.html>).
     ///
     /// Args:
@@ -218,18 +261,18 @@ impl PitchClassSet {
     ///
     /// Returns:
     ///     int: Number of common pitch classes between pitch-class set and its transposition by ``tn``.
-    fn count_common_tones_under_tn(&self, tn: i8) -> PyResult<i8> {
+    fn count_common_tones_under_tn(&self, tn: i8) -> i8 {
         let n = tn.rem_euclid(12);
         if n == 0 {
-            return Ok(self.pcs.len() as i8);
+            return self.pcs.len() as i8;
         }
-        let iv = interval_class_vector(&self.pcs);
-        let ic = semitones_to_interval_class(n);
+        let iv = interval_class_vector(&self.pcs_i8());
+        let ic = semitones_to_ic(n);
         let mut count = iv[(ic - 1) as usize];
         if n == 6 {
             count *= 2;
         }
-        Ok(count)
+        count
     }
 
     /// Transpose the pitch-class set by a given number of semitones.
@@ -241,64 +284,23 @@ impl PitchClassSet {
     ///     tn (int): The number of semitones to transpose by.
     ///         Must be in the range -11 to 11.
     fn transpose_by(&self, tn: i8) -> PyResult<Self> {
-        semitone_guard(tn)?;
+        validate_semitones(tn)?;
         Ok(Self {
-            pcs: self.pcs.iter().map(|&pc| wrap_pc_0_11(pc + tn)).collect(),
+            pcs: self.pcs.iter().map(|&pc| pc.transpose(tn)).collect(),
         })
     }
 }
 
-fn sorted_pitch_classes(pcs: &[i8]) -> Vec<i8> {
-    let mut v = pcs.to_vec();
+// ============ Normal form / prime form ============
+
+fn sorted_pcs_i8(pcs: &[PitchClass]) -> Vec<i8> {
+    let mut v: Vec<i8> = pcs.iter().copied().map(PitchClass::raw).collect();
     v.sort_unstable();
     v
 }
 
-/// Counts of interval classes 1..=6 for all unordered pairs in the set.
-fn interval_class_vector(pcs: &[i8]) -> Vec<i8> {
-    let sorted = sorted_pitch_classes(pcs);
-    let n = sorted.len();
-    let mut counts = [0i8; 6];
-    for i in 0..n {
-        for j in (i + 1)..n {
-            let d = sorted[j] - sorted[i];
-            let ic = semitones_to_interval_class(d);
-            counts[(ic - 1) as usize] += 1;
-        }
-    }
-    counts.to_vec()
-}
-
-/// Map a pitch interval in semitones (1..=11) to its interval class (1..=6).
-#[inline]
-fn semitones_to_interval_class(d: i8) -> i8 {
-    debug_assert!((1..=11).contains(&d));
-    if d > 6 { 12 - d } else { d }
-}
-
-/// Normal form from sorted distinct pitch classes (`src/specs/pitchclass.md`).
-fn get_normal_form(sorted_pcs: &[i8]) -> Vec<i8> {
-    let n = sorted_pcs.len();
-    match n {
-        0 => vec![],
-        1 => vec![sorted_pcs[0].rem_euclid(12)],
-        _ => std::iter::once(get_rotations(sorted_pcs))
-            .map(get_candidates)
-            .map(|candidates| break_ties(candidates, n))
-            .map(|winners| {
-                wrap_pitch_classes_line(
-                    winners
-                        .first()
-                        .expect("at least one rotation survives tie-breaking"),
-                )
-            })
-            .next()
-            .expect("once() always yields one item"),
-    }
-}
-
 /// Transpose a normal-order row so the first pitch class is 0 (`p - p₀` mod 12).
-fn transpose_prime_to_zero(line: &[i8]) -> Vec<i8> {
+fn transpose_to_zero(line: &[i8]) -> Vec<i8> {
     if line.is_empty() {
         return vec![];
     }
@@ -306,10 +308,24 @@ fn transpose_prime_to_zero(line: &[i8]) -> Vec<i8> {
     line.iter().map(|&p| (p - t).rem_euclid(12)).collect()
 }
 
+/// Normal form from sorted distinct pitch classes (`src/specs/pitchclass.md`).
+fn normal_form(sorted_pcs: &[i8]) -> Vec<i8> {
+    match sorted_pcs.len() {
+        0 => vec![],
+        1 => vec![sorted_pcs[0].rem_euclid(12)],
+        n => {
+            let rotations = build_rotations(sorted_pcs);
+            let candidates = trim_to_min_span(rotations);
+            let winners = break_ties(candidates, n);
+            wrap_line_to_pcs(winners.first().expect("at least one rotation survives tie-breaking"))
+        }
+    }
+}
+
 /// All cyclic rotations as linear pitch rows (`src/specs/pitchclass.md`).
 ///
 /// `sorted_pcs` must have length ≥ 2.
-fn get_rotations(sorted_pcs: &[i8]) -> Vec<Vec<i8>> {
+fn build_rotations(sorted_pcs: &[i8]) -> Vec<Vec<i8>> {
     let n = sorted_pcs.len();
     (0..n).map(|i| rotation(sorted_pcs, i)).collect()
 }
@@ -322,7 +338,7 @@ fn rotation(sorted_pcs: &[i8], start: usize) -> Vec<i8> {
 }
 
 /// Step 1 — keep rotations with minimal total span `r[n-1] - r[0]`.
-fn get_candidates(rotations: Vec<Vec<i8>>) -> Vec<Vec<i8>> {
+fn trim_to_min_span(rotations: Vec<Vec<i8>>) -> Vec<Vec<i8>> {
     let n = rotations[0].len();
     let min_span = rotations
         .iter()
@@ -355,43 +371,48 @@ fn break_ties(mut candidates: Vec<Vec<i8>>, n: usize) -> Vec<Vec<i8>> {
 }
 
 /// Map linear pitches back to canonical pitch-class integers (`p % 12`, Euclidean modulus).
-fn wrap_pitch_classes_line(line: &[i8]) -> Vec<i8> {
+fn wrap_line_to_pcs(line: &[i8]) -> Vec<i8> {
     line.iter().map(|&p| p.rem_euclid(12)).collect()
 }
 
-fn semitone_guard(semitones: i8) -> PyResult<()> {
-    if !(-11..=11).contains(&semitones) {
-        return Err(pyo3::exceptions::PyValueError::new_err(
-            "by_semitones must be within the range (-11)-11",
-        ));
+// ============ Interval-class vector & common tones ============
+
+/// Map a pitch interval (in semitones, any representative mod 12) to interval class 0–6.
+///
+/// `0` means unison/octave (interval ≡ 0 mod 12); classes `1`–`6` are the usual interval classes.
+fn semitones_to_ic(semitones: i8) -> i8 {
+    let d = semitones.rem_euclid(12);
+    if d == 0 {
+        0
+    } else if d > 6 {
+        12 - d
+    } else {
+        d
     }
-    Ok(())
 }
 
-fn pc_guard(pc: i8) -> PyResult<()> {
-    if !(0..=11).contains(&pc) {
-        return Err(pyo3::exceptions::PyValueError::new_err(
-            "pc must be within the range 0-11",
-        ));
+/// Counts of interval classes 1..=6 for all unordered pairs in the set.
+fn interval_class_vector(pcs: &[i8]) -> Vec<i8> {
+    let mut sorted = pcs.to_vec();
+    sorted.sort_unstable();
+    let n = sorted.len();
+    let mut counts = [0i8; 6];
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let d = sorted[j] - sorted[i];
+            let ic = semitones_to_ic(d);
+            counts[(ic - 1) as usize] += 1;
+        }
     }
-    Ok(())
+    counts.to_vec()
 }
 
-#[inline]
-fn wrap_pc_0_11(mut x: i8) -> i8 {
-    // x is in a small range (for transpose: -11..=22)
-    if x < 0 {
-        x += 12;
-    } else if x >= 12 {
-        x -= 12;
-    }
-    x
-}
+// ============ Free pyfunctions ============
 
-#[inline]
-fn invert_pc(pc: i8) -> i8 {
-    // (12 - pc) mod 12, but pc is 0..=11
-    if pc == 0 { 0 } else { 12 - pc }
+fn map_ordered_set<F: Fn(PitchClass) -> PitchClass>(set: &[i8], f: F) -> PyResult<Vec<i8>> {
+    set.iter()
+        .map(|&pc| PitchClass::try_new(pc).map(|p| f(p).raw()))
+        .collect()
 }
 
 /// Invert a pitch class around 0.
@@ -417,8 +438,7 @@ fn invert_pc(pc: i8) -> i8 {
 #[pyfunction]
 #[pyo3(signature = (pc))]
 pub fn invert(pc: i8) -> PyResult<i8> {
-    pc_guard(pc)?;
-    Ok(invert_pc(pc))
+    Ok(PitchClass::try_new(pc)?.invert().raw())
 }
 
 /// Transpose a pitch class by a given number of semitones.
@@ -442,9 +462,8 @@ pub fn invert(pc: i8) -> PyResult<i8> {
 #[pyfunction]
 #[pyo3(signature = (by_semitones, pc))]
 pub fn transpose(by_semitones: i8, pc: i8) -> PyResult<i8> {
-    semitone_guard(by_semitones)?;
-    pc_guard(pc)?;
-    Ok(wrap_pc_0_11(by_semitones + pc))
+    validate_semitones(by_semitones)?;
+    Ok(PitchClass::try_new(pc)?.transpose(by_semitones).raw())
 }
 
 /// Transpose an ordered pitch-class row by a given number of semitones.
@@ -469,14 +488,8 @@ pub fn transpose(by_semitones: i8, pc: i8) -> PyResult<i8> {
 #[pyfunction]
 #[pyo3(signature = (by_semitones, ordered_set))]
 pub fn transpose_ordered_set(by_semitones: i8, ordered_set: Vec<i8>) -> PyResult<Vec<i8>> {
-    semitone_guard(by_semitones)?;
-
-    let mut out = Vec::with_capacity(ordered_set.len());
-    for &pc in &ordered_set {
-        pc_guard(pc)?;
-        out.push(wrap_pc_0_11(pc + by_semitones));
-    }
-    Ok(out)
+    validate_semitones(by_semitones)?;
+    map_ordered_set(&ordered_set, |pc| pc.transpose(by_semitones))
 }
 
 /// Invert an ordered pitch-class row around 0.
@@ -497,12 +510,7 @@ pub fn transpose_ordered_set(by_semitones: i8, ordered_set: Vec<i8>) -> PyResult
 #[pyfunction]
 #[pyo3(signature = (ordered_set))]
 pub fn invert_ordered_set(ordered_set: Vec<i8>) -> PyResult<Vec<i8>> {
-    let mut out = Vec::with_capacity(ordered_set.len());
-    for &pc in &ordered_set {
-        pc_guard(pc)?;
-        out.push(invert_pc(pc));
-    }
-    Ok(out)
+    map_ordered_set(&ordered_set, PitchClass::invert)
 }
 
 /// Map a pitch interval (in semitones, any representative mod 12) to interval class 0–6.
@@ -511,10 +519,6 @@ pub fn invert_ordered_set(ordered_set: Vec<i8>) -> PyResult<Vec<i8>> {
 /// interval classes for distinct pitch classes.
 #[pyfunction]
 #[pyo3(signature = (interval))]
-pub fn interval_class(interval: i8) -> PyResult<i8> {
-    let d = interval.rem_euclid(12);
-    if d == 0 {
-        return Ok(0);
-    }
-    Ok(semitones_to_interval_class(d))
+pub fn interval_class(interval: i8) -> i8 {
+    semitones_to_ic(interval)
 }

--- a/src/specs/refactor.md
+++ b/src/specs/refactor.md
@@ -1,0 +1,421 @@
+We are going to do a refactor of the codebase, following the SOLID principles. I have a smaller version of these stored in ./cursor/rules/solid-rust.mdc
+
+We should also follow DRY (Don't Repeat Yourself)
+
+## Single Responsibility Principle
+
+The Single Responsibility Principle says that a module, struct, or function should have one clear responsibility and one main reason to change. In Rust, this usually means keeping types focused on what they represent and moving unrelated behavior into separate functions, traits, or modules.
+
+### The Bad Example
+
+Here is a struct that is responsible both for representing data and for handling file input/output:
+
+```rust
+use std::fs::File;
+use std::io::{self, Read, Write};
+
+struct Config {
+    filename: String,
+    data: String,
+}
+
+impl Config {
+    fn new(filename: String, data: String) -> Self {
+        Config { filename, data }
+    }
+
+    fn read(&mut self) -> io::Result<()> {
+        let mut file = File::open(&self.filename)?;
+        file.read_to_string(&mut self.data)?;
+        Ok(())
+    }
+
+    fn write(&self) -> io::Result<()> {
+        let mut file = File::create(&self.filename)?;
+        file.write_all(self.data.as_bytes())?;
+        Ok(())
+    }
+}
+```
+
+In this example, the `Config` struct is responsible for both storing configuration data and performing file I/O. That means changes to either the configuration format or the way files are read and written would require modifying `Config`. This violates SRP because it combines data representation with persistence concerns.
+
+### The Good Example
+
+We refactor the code by separating concerns:
+
+```rust
+use std::io::{Read, Write};
+use std::fs::File;
+
+        use std::io::Write;
+
+struct Config {
+    data: String,
+}
+
+impl Config {
+    fn new(data: String) -> Self {
+        Config { data }
+    }
+}
+
+struct FileHandler;
+
+impl FileHandler {
+    fn read(filename: &str) -> io::Result<Config> {
+        let mut file = File::open(filename)?;
+        let mut data = String::new();
+        file.read_to_string(&mut data)?;
+        Ok(Config::new(data))
+    }
+
+    fn write(filename: &str, config: &Config) -> io::Result<()> {
+        let mut file = File::create(filename)?;
+        file.write_all(config.data.as_bytes())?;
+        Ok(())
+    }
+}
+```
+
+## Open/Closed Principle
+
+The Open/Closed Principle (OCP) states that software entities should be open for extension but closed for modification.
+In Rust, we achieve this through traits and implementations, allowing us to add new behavior without altering existing code.
+
+### The Bad Example
+
+Let's consider this example about a function that calculates areas for different shapes:
+
+```rust
+enum Shape {
+    Circle(f64),         // radius
+    Rectangle(f64, f64), // width, height
+}
+
+fn calculate_area(shape: &Shape) -> f64 {
+    match shape {
+        Shape::Circle(radius) => std::f64::consts::PI * radius * radius,
+        Shape::Rectangle(width, height) => width * height,
+    }
+}
+```
+
+In this setup, adding a new shape, like a Triangle, requires modifying the `Shape` enum and the `calculate_area` function. This violates OCP since we have to modify existing code to extend functionality.
+
+### The Good Example
+
+Let's use traits to make the code open for extension:
+
+```rust
+trait Shape {
+    fn area(&self) -> f64;
+}
+
+struct Circle {
+    radius: f64,
+}
+
+impl Shape for Circle {
+    fn area(&self) -> f64 {
+        std::f64::consts::PI * self.radius * self.radius
+    }
+}
+
+struct Rectangle {
+    width: f64,
+    height: f64,
+}
+
+impl Shape for Rectangle {
+    fn area(&self) -> f64 {
+        self.width * self.height
+    }
+}
+
+// Adding a new shape doesn't modify existing code
+struct Triangle {
+    base: f64,
+    height: f64,
+}
+
+impl Shape for Triangle {
+    fn area(&self) -> f64 {
+        0.5 * self.base * self.height
+    }
+}
+
+fn calculate_area(shape: &dyn Shape) -> f64 {
+    shape.area()
+}
+```
+
+In the refactored code, the Shape trait defines a common interface that should be implemented by each shape struct. Adding a new shape involves creating a new struct and impl block without modifying existing code, not even the calculate_area function since it operates on any object that implements Shape.
+
+By adhering to OCP, we ensure our codebase is resilient to change and easy to extend.
+
+## Liskov Substitution Principle
+
+The Liskov Substitution Principle (LSP) asserts that subtypes must be substitutable for their base types without altering the correctness of the program. In Rust, this means that any type implementing a trait should be usable wherever that trait is expected, without causing unexpected behavior or errors.
+
+### The Bad Example
+
+Consider the following example where we define a Bird trait:
+
+```rust
+trait Bird {
+    fn fly(&self);
+}
+
+struct Eagle;
+
+impl Bird for Eagle {
+    fn fly(&self) {
+        println!("The eagle soars high into the sky.");
+    }
+}
+
+struct Penguin;
+
+impl Bird for Penguin {
+    fn fly(&self) {
+        panic!("Penguins can't fly!");
+    }
+}
+```
+
+In this code, both Eagle and Penguin implement the Bird trait, which requires a fly method. While an Eagle can fly, a Penguin cannot. The Penguin's fly method panics when called. Substituting a Penguin where a Bird is expected could lead to a runtime panic, violating the LSP. The fly method's contract implies that any Bird can fly, but Penguin does not fulfill this contract.
+
+### The Good Example
+
+Let's refactor the code to adhere to the LSP by separating flying behavior from the Bird trait:
+
+```rust
+trait Bird {
+    fn lay_egg(&self);
+}
+
+trait Flyable {
+    fn fly(&self);
+}
+
+struct Eagle;
+
+impl Bird for Eagle {
+    fn lay_egg(&self) {
+        println!("The eagle lays an egg.");
+    }
+}
+
+impl Flyable for Eagle {
+    fn fly(&self) {
+        println!("The eagle soars high into the sky.");
+    }
+}
+
+struct Penguin;
+
+impl Bird for Penguin { // Note: Penguin does not implement Flyable
+    fn lay_egg(&self) {
+        println!("The penguin lays an egg.");
+    }
+}
+```
+
+In the refactored code, we've split the behaviors into two traits: Bird and Flyable. The Bird trait includes behaviors common to all birds, such as lay_egg, while the Flyable trait defines the flying behavior. Eagle implements both Bird and Flyable because it can lay eggs and fly. Penguin implements only Bird since it lays eggs but cannot fly.
+
+By doing this, we ensure that any type implementing Flyable truly supports flying, preventing runtime panics. This adheres to the LSP because substituting any Bird or Flyable with their respective implementors will not lead to unexpected behavior.
+
+## Interface Segregation Principle
+
+The Interface Segregation Principle (ISP) advises that clients should not be forced to depend upon interfaces they do not use. In Rust, this means designing small, focused traits.
+
+### The Bad Example
+
+Here's a trait that combines multiple unrelated functionalities:
+
+```rust
+trait Entity {
+    fn save(&self);
+    fn load(&self);
+    fn validate(&self) -> bool;
+}
+
+struct User;
+
+impl Entity for User {
+    fn save(&self) {
+        println!("Saving user");
+    }
+
+    fn load(&self) {
+        println!("Loading user");
+    }
+
+    fn validate(&self) -> bool {
+        // User validation logic
+        true
+    }
+}
+
+struct Config;
+
+impl Entity for Config {
+    fn save(&self) {
+        println!("Saving config");
+    }
+
+    fn load(&self) {
+        println!("Loading config");
+    }
+
+    fn validate(&self) -> bool {
+        // Config doesn't need validation, but forced to implement
+        true
+    }
+}
+```
+
+In this code, Config is forced to implement validate, which may not be relevant. Thus, ISP is violated by requiring structs to implement methods they don't really need.
+
+### The Good Example
+
+Let's split the trait into smaller, more focused traits:
+
+```rust
+trait Persistable {
+    fn save(&self);
+    fn load(&self);
+}
+
+trait Validatable {
+    fn validate(&self) -> bool;
+}
+
+struct User;
+
+impl Persistable for User {
+    fn save(&self) {
+        println!("Saving user");
+    }
+
+    fn load(&self) {
+        println!("Loading user");
+    }
+}
+
+impl Validatable for User {
+    fn validate(&self) -> bool {
+        // User validation logic
+        true
+    }
+}
+
+struct Config;
+
+impl Persistable for Config {
+    fn save(&self) {
+        println!("Saving config");
+    }
+
+    fn load(&self) {
+        println!("Loading config");
+    }
+}
+
+// No need to implement `Validatable` for `Config`
+```
+
+In this code, we have more focused interfaces, that is, smaller traits representing specific behaviors. This means that types can implement only the traits relevant to them, making it easier to compose behaviors without unnecessary code.
+
+By adhering to ISP, we create a modular and flexible codebase where components are not burdened by unnecessary dependencies.
+
+## Dependency Inversion Principle
+
+The Dependency Inversion Principle (DIP) states that high-level modules should not depend on low-level modules; both should depend on abstractions. In Rust, we use traits to define abstractions that decouple modules. Overall, I don't really care too much about this one in Rust. So, you should still see if there are opportunities to do this, but we don't need to do too much with it.
+
+### The Bad Example
+
+Consider a NotificationService that directly depends on a concrete EmailSender:
+
+```rust
+struct EmailSender;
+
+impl EmailSender {
+    fn send(&self, to: &str, body: &str) {
+        println!("Sending email to {}: {}", to, body);
+    }
+}
+
+struct NotificationService {
+    email_sender: EmailSender,
+}
+
+impl NotificationService {
+    fn new(email_sender: EmailSender) -> Self {
+        NotificationService { email_sender }
+    }
+
+    fn notify(&self, user: &str, message: &str) {
+        self.email_sender.send(user, message);
+    }
+}
+```
+
+In this code, NotificationService depends directly on EmailSender, which is a concrete implementation. This makes it difficult to substitute EmailSender with another sender (e.g., SmsSender), thus violating the DIP by coupling high-level logic with low-level implementation.
+
+### The Good Example
+
+Let's introduce an abstraction using a trait:
+
+```rust
+trait Messenger {
+    fn send(&self, to: &str, body: &str);
+}
+
+struct EmailSender;
+
+impl Messenger for EmailSender {
+    fn send(&self, to: &str, body: &str) {
+        println!("Sending email to {}: {}", to, body);
+    }
+}
+
+struct SmsSender;
+
+impl Messenger for SmsSender {
+    fn send(&self, to: &str, body: &str) {
+        println!("Sending SMS to {}: {}", to, body);
+    }
+}
+
+struct NotificationService<'a> {
+    messenger: &'a dyn Messenger,
+}
+
+impl<'a> NotificationService<'a> {
+    fn new(messenger: &'a dyn Messenger) -> Self {
+        NotificationService { messenger }
+    }
+
+    fn notify(&self, user: &str, message: &str) {
+        self.messenger.send(user, message);
+    }
+}
+```
+
+In the refactored code, Messenger trait defines an abstraction for sending messages. NotificationService depends on the Messenger trait, not on a concrete implementation; hence, we can inject any messenger that implements Messenger, promoting flexibility.
+
+By adhering to DIP, we create a modular architecture where components are interchangeable and extensible.
+
+## Don't repeat yourself
+
+Traits and Generics: Define shared behavior across different types using traits. Generics allow functions to operate on any type that implements specific trait bounds, reducing the need for duplicate function implementations.
+
+Macros (macro_rules! and Procedural): Factor out repetitive boilerplate that cannot be handled by standard functions, such as repeating complex test suites or implementing the same logic for multiple primitive types.
+
+Closures: Use closures to capture local environments and abstract away repetitive execution patterns within a single scope.
+
+Enums and Pattern Matching: Use enums to represent varying states or data types, then use pattern matching to handle them in a single, unified logic path rather than separate functions.
+
+Ownership and References: Design functions to take references (&T) instead of taking ownership (T) where possible. This allows the same logic to be reused across different parts of a program without unnecessary data cloning.

--- a/src/specs/voicing.md
+++ b/src/specs/voicing.md
@@ -66,3 +66,5 @@ for voicing in a_minor_voicings:
     print(voicing.distance_to(a_minor_voicing2, mode=SumAbs)) # 10
 
 ```
+
+Let's write this API in Rust using structs and impl blocks.

--- a/src/voicing.rs
+++ b/src/voicing.rs
@@ -156,12 +156,7 @@ impl VoiceLeading {
 }
 
 fn validate_non_empty_pcs(pcs: &PitchClassSet) -> PyResult<()> {
-    if pcs.pcs.is_empty() {
-        return Err(pyo3::exceptions::PyValueError::new_err(
-            "pitch-class set must not be empty",
-        ));
-    }
-    Ok(())
+    crate::error::require(!pcs.is_empty(), "pitch-class set must not be empty")
 }
 
 fn voicing_span(notes: &[i32]) -> i32 {
@@ -223,10 +218,11 @@ fn enumerate_permutation_in_range(
 }
 
 fn voicings_in_keynum_range(pcs: &PitchClassSet, min_keynum: i32, max_keynum: i32) -> Vec<Voicing> {
+    let pcs_raw = pcs.pcs_i8();
     let mut out = Vec::new();
     let mut notes = Vec::new();
     let mut raw = Vec::new();
-    for perm in permutations(&pcs.pcs) {
+    for perm in permutations(&pcs_raw) {
         raw.clear();
         enumerate_permutation_in_range(&perm, min_keynum, max_keynum, &mut notes, &mut raw);
         out.extend(raw.drain(..).map(|notes| Voicing { notes }));
@@ -243,9 +239,10 @@ fn voicings_in_keynum_range(pcs: &PitchClassSet, min_keynum: i32, max_keynum: i3
 #[pyo3(signature = (pcs, octave = 4))]
 pub fn voicings_from_pc_set(pcs: &PitchClassSet, octave: i32) -> PyResult<Vec<Voicing>> {
     validate_non_empty_pcs(pcs)?;
-    let anchor_pc = pcs.pcs[0];
+    let pcs_raw = pcs.pcs_i8();
+    let anchor_pc = pcs.first_pc_i8().expect("non-empty by validation");
     let anchor_midi = midi_at_octave(anchor_pc, octave);
-    let perms = permutations(&pcs.pcs);
+    let perms = permutations(&pcs_raw);
     Ok(perms
         .into_iter()
         .map(|perm| Voicing {


### PR DESCRIPTION
## Goals

Keep the Python-facing surface (`PitchClassSet`, `transpose`, `invert`, `transpose_ordered_set`, `invert_ordered_set`, `interval_class`) behaviorally identical so that [python/tests/test_pitchclass.py](python/tests/test_pitchclass.py) and the examples in [python/examples/](python/examples/) keep passing after a rebuild. All structural changes are in Rust + the one consumer module ([src/voicing.rs](src/voicing.rs)).

## 1. Add an internal `PitchClass(i8)` newtype

A new top section of [src/pitchclass.rs](src/pitchclass.rs):

```rust
#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
struct PitchClass(i8);

impl PitchClass {
    fn try_new(pc: i8) -> PyResult<Self> {
        crate::error::require((0..=11).contains(&pc), "pc must be within the range 0-11")?;
        Ok(Self(pc))
    }
    fn raw(self) -> i8 { self.0 }
    fn invert(self) -> Self { Self((-self.0).rem_euclid(12)) }
    fn transpose(self, semitones: i8) -> Self { Self((self.0 + semitones).rem_euclid(12)) }
}
```

This becomes the only place modular-12 arithmetic for individual pitch classes lives, replacing today's three separate helpers `wrap_pc_0_11`, `invert_pc`, and the implicit `+ tn` math inside the methods.

## 2. Encapsulate `PitchClassSet`

- Change the field from `pub pcs: Vec<i8>` to `pcs: Vec<PitchClass>` (private).
- Add `pub(crate)` accessors for cross-module use by [src/voicing.rs](src/voicing.rs):
  - `pub(crate) fn len(&self) -> usize`
  - `pub(crate) fn is_empty(&self) -> bool`
  - `pub(crate) fn pcs_i8(&self) -> Vec<i8>` (cheap clone; max 12 elements)
  - `pub(crate) fn first_pc_i8(&self) -> Option<i8>`
- The Python `#[getter] fn pitch_classes(&self) -> Vec<i8>` becomes `self.pcs.iter().map(PitchClass::raw).collect()`.

## 3. Consolidate validation through `error::require`

[src/error.rs](src/error.rs) already exposes `require(ok, msg) -> PyResult<()>` but `pitchclass.rs` doesn't use it. Replace every hand-rolled `if !cond { return Err(PyValueError::new_err(...)) }` (the bodies of `pc_guard` and `semitone_guard`, plus the `has_unique_elements` check in `new`) with `error::require(...)?`. After this, `pc_guard` and `semitone_guard` go away — validation happens inside `PitchClass::try_new` and a single new `validate_semitones(s: i8)` helper.

## 4. DRY the ordered-set helpers

Today `transpose_ordered_set` and `invert_ordered_set` repeat the same "validate + per-element transform" loop. Replace with one private helper:

```rust
fn map_ordered_set<F: Fn(PitchClass) -> PitchClass>(set: &[i8], f: F) -> PyResult<Vec<i8>> {
    set.iter()
        .map(|&pc| PitchClass::try_new(pc).map(&f).map(PitchClass::raw))
        .collect()
}
```

Then the two pyfunctions collapse to one line each:

```rust
pub fn transpose_ordered_set(by_semitones: i8, ordered_set: Vec<i8>) -> PyResult<Vec<i8>> {
    validate_semitones(by_semitones)?;
    map_ordered_set(&ordered_set, |pc| pc.transpose(by_semitones))
}
pub fn invert_ordered_set(ordered_set: Vec<i8>) -> PyResult<Vec<i8>> {
    map_ordered_set(&ordered_set, PitchClass::invert)
}
```

Free `transpose(by_semitones, pc)` and `invert(pc)` also route through `PitchClass`, eliminating the parallel `wrap_pc_0_11` / `invert_pc` helpers.

## 5. Unify `interval_class`

Today there are two near-duplicates:

- `semitones_to_interval_class(d)` — `debug_assert!(1..=11)`, returns 1..=6.
- `pub fn interval_class(interval)` — handles 0 separately, returns 0..=6.

Replace with a single private function that accepts any `i8` and returns 0..=6 by folding via `rem_euclid(12)`. Both the pyfunction and the internal interval-class-vector pass through it. Drop the unnecessary `PyResult` on the pyfunction (it can't fail).

## 6. Drop pointless `PyResult` returns

The following methods/functions have no failure path today; remove the `PyResult` wrapper to make that explicit (Python still sees the same return types):

- `PitchClassSet::interval_vector` -> `Vec<i8>`
- `PitchClassSet::subsets` -> `Vec<Self>` (PyO3 still raises `OverflowError` for negative `min_size` at int->usize conversion, so [the `test_negative_min_size_raises_overflow_error](python/tests/test_pitchclass.py)` test keeps passing)
- `PitchClassSet::count_common_tones_under_tn` -> `i8`
- Free `interval_class` -> `i8`

`PitchClassSet::new`, `transpose_by`, `forte_num`, `transpose`, `invert`, `transpose_ordered_set`, and `invert_ordered_set` keep `PyResult` because they have real validation/lookup failures.

## 7. Simplify `get_normal_form`

The current body is a contrived `std::iter::once(...).map(...).map(...).map(...).next().expect(...)` chain. Replace with straight-line code:

```rust
fn normal_form(sorted_pcs: &[i8]) -> Vec<i8> {
    match sorted_pcs.len() {
        0 => vec![],
        1 => vec![sorted_pcs[0].rem_euclid(12)],
        n => {
            let rotations = build_rotations(sorted_pcs);
            let candidates = trim_to_min_span(rotations);
            let winners = break_ties(candidates, n);
            wrap_line_to_pcs(winners.first().expect("at least one rotation survives"))
        }
    }
}
```

Helper renames for clarity: `get_rotations -> build_rotations`, `get_candidates -> trim_to_min_span`, `wrap_pitch_classes_line -> wrap_line_to_pcs`.

## 8. Reorganize `pitchclass.rs` with section dividers

Keep the file single-file as requested. Order the sections top-down so primitives precede composites:

- `// ============ PitchClass primitive ============` — newtype + impl, `validate_semitones`
- `// ============ PitchClassSet (PyO3 class) ============` — struct + `#[pymethods]`, accessors
- `// ============ Normal form / prime form ============` — `normal_form`, rotation/candidate/tie-break helpers
- `// ============ Interval-class vector & common tones ============` — `interval_class_vector`, `semitones_to_ic`
- `// ============ Free pyfunctions ============` — `transpose`, `invert`, `transpose_ordered_set`, `invert_ordered_set`, `interval_class`

## 9. Update `voicing.rs`

Replace the four direct field accesses in [src/voicing.rs](src/voicing.rs) (today at lines 159, 229, 246, 248) with the new accessors. The hot path is unchanged — we materialize a `Vec<i8>` once per call (max 12 elements):

```rust
fn validate_non_empty_pcs(pcs: &PitchClassSet) -> PyResult<()> {
    crate::error::require(!pcs.is_empty(), "pitch-class set must not be empty")
}

// in voicings_in_keynum_range / voicings_from_pc_set:
let raw = pcs.pcs_i8();
let anchor_pc = pcs.first_pc_i8().expect("non-empty by validation");
for perm in permutations(&raw) { ... }
```

No signature changes to the public Python-facing voicing API.